### PR TITLE
Increase checkCount to 100

### DIFF
--- a/src/pullRequest.ts
+++ b/src/pullRequest.ts
@@ -115,7 +115,7 @@ async function listPullRequests(ctx: GhContext): Promise<PullRequestInfo[]> {
 }
 
 const pullRequestCount = 50
-const checkCount = 50
+const checkCount = 100
 const labelCount = 10
 
 const pullRequestFragment = `


### PR DESCRIPTION
Our builds regularly have >50 checks (based on number of changed components) and since the final "success" check is always the last one, update-branch doesn't find it. This increases the number to a 100 which is admittedly just a patch but it will help us very much in the short term evaluating this action.

I can work on making this configurable in a separate PR if you want. 