### PR TITLE
Allow configuration of fetch count

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Merge your pull request in order when enabled the `Require branches to be up to 
 Inspired by [Merge Queue feature of Mergify](https://mergify.io/features/merge-queue).
 
 > Safety
-> 
+>
 > Do not merge broken pull requests. By merging your pull requests serially using a queue, your code is safe. Each pull request is tested with the latest CI code.
 
 > Save CI time
-> 
+>
 > Rather than overconsuming your CI time by trying to merge multiple pull requests, just run it once before the pull request gets merged.
 
 ## Quick Start
@@ -18,7 +18,7 @@ Inspired by [Merge Queue feature of Mergify](https://mergify.io/features/merge-q
 
 1. Enable `Allow auto-merge` in `Settings/Options`.
 
-3. Create a workflow file (`.github/workflow/update-branch.yaml`):
+2. Create a workflow file (`.github/workflow/update-branch.yaml`):
 
 Example:
 
@@ -59,6 +59,12 @@ jobs:
           requiredStatusChecks: |
             build_pr
             WIP
+          # Optionally set the maximum amount of pull requests to match against (default: 50)
+          fetchMaxPr: 50
+          # Optionally set the maximum amount of pull request checks to fetch (default: 100)
+          fetchMaxPrChecks: 100
+          # Optionally set the maximum amount of pull request labels to fetch (default: 10)
+          fetchMaxPrLabels: 10
 ```
 
 If you are using a personal access token and it has permission to access branch protection rules, you can set your jobs like:

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,18 @@ inputs:
     required: false
     description: 'The name pattern of GitHub branch protection rules to apply. The default behavior is to find the name pattern of main or master. Require personal access token to let this feature work.'
     default: ''
+  fetchMaxPr:
+    required: false
+    description: 'The maximum amount of pull request fetch when searching for eligible pull requests.'
+    default: '50'
+  fetchMaxPrChecks:
+    required: false
+    description: 'The maximum amount of pull request checks to fetch when searching for requiredStatusChecks.'
+    default: '100'
+  fetchMaxPrLabels:
+    required: false
+    description: 'The maximum amount of pull request labels to fetch when searching for requiredLabels.'
+    default: '10'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import {
   mergePullRequest,
   updateBranch
 } from './pullRequest'
-import {Condition, GhContext, IssueInfo, RecordBody} from './type'
+import {Condition, FetchConfig, GhContext, IssueInfo, RecordBody} from './type'
 import {getViewerName} from './user'
 import {
   createIssueBody,
@@ -39,10 +39,15 @@ async function run(): Promise<void> {
     const protectedBranchNamePattern = core.getInput(
       'protectedBranchNamePattern'
     )
+    const fetchConfig: FetchConfig = {
+      prs: parseInt(core.getInput('fetchMaxPr')),
+      checks: parseInt(core.getInput('fetchMaxPrChecks')),
+      labels: parseInt(core.getInput('fetchMaxPrLabels'))
+    }
 
     const octokit = github.getOctokit(token)
     const {owner, repo} = github.context.repo
-    const ctx: GhContext = {octokit, owner, repo, autoMergeMethod}
+    const ctx: GhContext = {octokit, owner, repo, autoMergeMethod, fetchConfig}
 
     const branchProtectionRule = await getBranchProtectionRule(
       ctx,

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,10 +1,17 @@
 import {Octokit} from '@octokit/core'
 
+export interface FetchConfig {
+  prs: number
+  labels: number
+  checks: number
+}
+
 export interface GhContext {
   octokit: Octokit
   owner: string
   repo: string
   autoMergeMethod: string
+  fetchConfig: FetchConfig
 }
 
 export interface Condition {


### PR DESCRIPTION
This allows users to specify the number of prs, labels and checks we fetch in the graphql query to github when searching for eligible pull requests. Followup of lcdsmao/update-branch#363.