### PR TITLE
Add ability to fetch pr runs in reverse order

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ jobs:
           fetchMaxPrChecks: 100
           # Optionally set the maximum amount of pull request labels to fetch (default: 10)
           fetchMaxPrLabels: 10
+          # The order pr checks should be fetched in. If the required checks are the last ones, consider setting to "last"
+          prChecksFetchOrder: first
 ```
 
 If you are using a personal access token and it has permission to access branch protection rules, you can set your jobs like:

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
     required: false
     description: 'The maximum amount of pull request labels to fetch when searching for requiredLabels.'
     default: '10'
+  prChecksFetchOrder:
+    required: false
+    description: 'The order pr checks should be fetched in. If the required checks are the last ones, consider setting to "last"'
+    default: 'first'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,10 +39,22 @@ async function run(): Promise<void> {
     const protectedBranchNamePattern = core.getInput(
       'protectedBranchNamePattern'
     )
+    const prRunsContextOrder = core.getInput('prChecksFetchOrder')
+    switch (prRunsContextOrder) {
+      case 'first':
+      case 'last':
+        break
+      default:
+        core.setFailed(
+          `prChecksFetchOrder=${prRunsContextOrder}. Valid values: [first, last]`
+        )
+        return
+    }
     const fetchConfig: FetchConfig = {
       prs: parseInt(core.getInput('fetchMaxPr')),
       checks: parseInt(core.getInput('fetchMaxPrChecks')),
-      labels: parseInt(core.getInput('fetchMaxPrLabels'))
+      labels: parseInt(core.getInput('fetchMaxPrLabels')),
+      prRunsContextOrder
     }
 
     const octokit = github.getOctokit(token)

--- a/src/pullRequest.ts
+++ b/src/pullRequest.ts
@@ -139,7 +139,7 @@ function getPullRequestFragment(cfg: FetchConfig): string {
     nodes {
       commit {
         statusCheckRollup {
-          contexts(first: ${cfg.checks}) {
+          contexts(${cfg.prRunsContextOrder}: ${cfg.checks}) {
             nodes {
               ... on CheckRun {
                 name

--- a/src/type.ts
+++ b/src/type.ts
@@ -4,6 +4,7 @@ export interface FetchConfig {
   prs: number
   labels: number
   checks: number
+  prRunsContextOrder: 'first' | 'last'
 }
 
 export interface GhContext {


### PR DESCRIPTION
We have over 100 PR runs. Increasing `fetchMaxPrChecks` to anything above 100 results in this error:

```
- Requesting 200 records on the `contexts` connection exceeds
the `first` limit of 100 records.
```

This adds the ability to specify fetching pr runs using `last` instead of `first` as the only pr runs we're interested in is the absolute last one.